### PR TITLE
Fix #alignemnt-definitions typo, but preserve old link semantics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="/template.v2.js"></script>
+  <script src="https://distill.pub/template.v2.js"></script>
   <style>.subgrid {
     grid-column: screen;
     display: grid;
@@ -351,7 +351,7 @@ a.section-number:hover {
             <a href="#alignment"><em>navigate to section "An overview of AI alignment"</em></a>
             <ul>
                 <li><a href="#learning-values-by-asking-questions">Learning values by asking humans questions</a></li>
-                <li><a href="#alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</a></li>
+                <li><a href="#alignment-definitions">Definitions of alignment: reasoning and reflective equilibrium</a></li>
                 <li><a href="#disagreements-uncertainty-inactions">Disagreements, uncertainty, and inaction: a hopeful
                         note</a></li>
                 <li><a href="#harder">Alignment gets harder as ML systems get smarter</a></li>
@@ -437,7 +437,7 @@ a.section-number:hover {
   </p><p>
     In practice, data in the form of interactive human questions may be quite limited, since people are slow and expensive relative to computers on many tasks.  Therefore, we can augment the "train from human questions" approach with static data from other sources, such as books or the internet<d-cite key="radford2018language"></d-cite>.  Ideally, the static data can be treated only as information about the world devoid of normative content: we can use it to learn patterns about the world, but the human data is needed to distinguish good patterns from bad.
   </p>
-  <h3 id="alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</h3>
+  <h3 id="alignment-definitions"><span id="alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</span></h3>
   <p>
     So far we have discussed asking humans direct questions about whether something is better or worse.  Unfortunately, we do not expect people to provide reliably correct answers in all cases, for several reasons:
   </p><p>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -50,7 +50,7 @@
             <a href="#alignment"><em>navigate to section "An overview of AI alignment"</em></a>
             <ul>
                 <li><a href="#learning-values-by-asking-questions">Learning values by asking humans questions</a></li>
-                <li><a href="#alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</a></li>
+                <li><a href="#alignment-definitions">Definitions of alignment: reasoning and reflective equilibrium</a></li>
                 <li><a href="#disagreements-uncertainty-inactions">Disagreements, uncertainty, and inaction: a hopeful
                         note</a></li>
                 <li><a href="#harder">Alignment gets harder as ML systems get smarter</a></li>
@@ -136,7 +136,7 @@
   </p><p>
     In practice, data in the form of interactive human questions may be quite limited, since people are slow and expensive relative to computers on many tasks.  Therefore, we can augment the "train from human questions" approach with static data from other sources, such as books or the internet<d-cite key="radford2018language"/>.  Ideally, the static data can be treated only as information about the world devoid of normative content: we can use it to learn patterns about the world, but the human data is needed to distinguish good patterns from bad.
   </p>
-  <h3 id="alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</h3>
+  <h3 id="alignment-definitions"><span id="alignemnt-definitions">Definitions of alignment: reasoning and reflective equilibrium</span></h3>
   <p>
     So far we have discussed asking humans direct questions about whether something is better or worse.  Unfortunately, we do not expect people to provide reliably correct answers in all cases, for several reasons:
   </p><p>


### PR DESCRIPTION
Right thing to do?